### PR TITLE
Refactor get req

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -6,16 +6,14 @@ import ClickableCards from "./components/ClickableCards/ClickableCards";
 import Search from "./components/Search/Search";
 import TrafficLights from "./components/TrafficLights/TrafficLights";
 
-
 function App() {
-
   const [teamAndMemberData, setTeamAndMemberData] = useState([]);
   const [teamData, setTeamData] = useState([]);
   const [teamStatuses, setTeamStatuses] = useState([]); // Define the teamStatuses state
 
   async function getAllTeamsAndMembersData() {
     try {
-      const response = await fetch("http://localhost:8000/api/members");
+      const response = await fetch("http://localhost:8000/teamPr"); //Change to render site before merging
       const data = await response.json();
       setTeamAndMemberData(data);
     } catch (error) {
@@ -35,7 +33,6 @@ function App() {
   useEffect(() => {
     getAllTeamsAndMembersData();
     getAllTeamData();
-   
   }, []);
 
   return (
@@ -62,20 +59,13 @@ function App() {
             />
           ))}
       </section>
-
       <TrafficLights
         teams={teamAndMemberData}
         setTeamStatuses={setTeamStatuses}
       />{" "}
       {/* Pass setTeamStatuses to TrafficLights */}
-
-
-
       <Form />
-        
-
     </div>
-
   );
 }
 

--- a/client/src/components/ClickableCards/ClickableCards.css
+++ b/client/src/components/ClickableCards/ClickableCards.css
@@ -1,10 +1,9 @@
 .team-box {
-  
   width: 90px;
   height: 90px;
   padding: 5px;
   font-size: 20px;
-  
+
   display: flex;
   align-items: center;
   justify-content: center;
@@ -16,13 +15,13 @@
 }
 
 .red {
-background-color: red;
-border: 2px solid red;
+  background-color: #ff0000;
+  border: 2px solid #ff0000;
 }
 
 .green {
-background-color: #008000;
-border: 2px solid #008000;
+  background-color: #008000;
+  border: 2px solid #008000;
 }
 .team-buttons {
   display: grid;

--- a/client/src/components/Search/Search.css
+++ b/client/src/components/Search/Search.css
@@ -22,7 +22,7 @@
 .team-info {
   display: grid;
   grid-template-columns: 11.5em 11.5em;
-  grid-template-rows: 6em 6em;
+  grid-template-rows: 6em;
   column-gap: 5px;
   row-gap: 5px;
   margin: 10px;

--- a/client/src/components/Search/Search.jsx
+++ b/client/src/components/Search/Search.jsx
@@ -35,7 +35,7 @@ const Search = ({ teamData }) => {
         />
       </form>
       {loadingTeamData ? (
-        <p>Please wait while we load quotes</p>
+        <p>Please wait while we load team information</p>
       ) : (
         <div>
           {" "}

--- a/server/config/router.js
+++ b/server/config/router.js
@@ -5,12 +5,12 @@ import { getTeamAndMemberData } from "../controllers/teamsController.js";
 import { allTeamMembersPRs } from "../controllers/teamsController.js";
 import { teamAndMemberInfo } from "../controllers/teamsController.js";
 
-router.route("/team").get(getTeamData);
+router.route("/team").get(getTeamData); // PATH TO GET ALL TEAMS INFORMATION FROM fp_teams TABLE IN DATABASE
 
-router.route("/team-members").get(getTeamAndMemberData);
+router.route("/team-members").get(getTeamAndMemberData); // PATH TO GET ALL TEAMS INFORMATION FROM fp_teams AND fp_members TABLES IN DATABASE. SEARCH QUERY INCLUDED
 
-router.route("/teamPr").get(allTeamMembersPRs);
+router.route("/teamPr").get(allTeamMembersPRs); //PATH TO GET ALL TEAMS PR COUNT
 
-router.route("/teamInfo/:id").get(teamAndMemberInfo);
+router.route("/teamInfo/:id").get(teamAndMemberInfo); //PATH TO GET SPECIFIC TEAM PR COUNT BY ID
 
 export default router;

--- a/server/controllers/teamsController.js
+++ b/server/controllers/teamsController.js
@@ -3,6 +3,7 @@ import { getAllTeamAndMembersInfo } from "../repositories/teamsRepository.js";
 import { getAllTeamMembersPRs } from "../repositories/teamsRepository.js";
 import { getTeamAndMemberInfo } from "../repositories/teamsRepository.js";
 
+// GETS ALL TEAMS INFORMATION FROM fp_teams TABLE IN DATABASE
 export async function getTeamData(req, res) {
   try {
     const allTeamNames = await getAllTeamInfo();
@@ -13,6 +14,8 @@ export async function getTeamData(req, res) {
   }
 }
 
+// GETS ALL TEAMS INFORMATION FROM fp_teams AND fp_members TABLES IN DATABASE
+// IF THERE IS A SEARCH QUERY IT MODIFIES THE DATA AND PRESENTS THE RESULTS BASED ON THE SEARCH QUERY
 export async function getTeamAndMemberData(req, res) {
   try {
     const searchTerm = req.query.term || "";
@@ -24,7 +27,8 @@ export async function getTeamAndMemberData(req, res) {
   }
 }
 
-// (TEAMS CONTROLLER)
+// RETURNS AN ARRAY OF OBJECTS FOR EACH TEAM
+// THIS INCLUDES THE NUMBER OF PULL REQUESTS DONE BY EACH MEMBER OF THE TEAM BASED ON THEIR GITHUB USERNAME
 export async function allTeamMembersPRs(req, res) {
   try {
     const teamsPRs = await getAllTeamMembersPRs();
@@ -35,6 +39,7 @@ export async function allTeamMembersPRs(req, res) {
   }
 }
 
+// RETURNS A SPECIFIC TEAM INFORMATION DEPENDING ON THE ID
 export async function teamAndMemberInfo(req, res) {
   try {
     const teamID = parseInt(req.params.id);

--- a/server/repositories/teamsRepository.js
+++ b/server/repositories/teamsRepository.js
@@ -2,11 +2,8 @@ import dotenv, { config } from "dotenv";
 dotenv.config();
 config();
 import { dataBase } from "../index.js";
-// import { Octokit } from "octokit";
 
-// const octokit = new Octokit({
-//   auth: process.env.TOKEN,
-// });
+// GETS ALL TEAMS INFORMATION FROM fp_teams TABLE IN DATABASE
 
 export async function getAllTeamInfo() {
   try {
@@ -23,6 +20,8 @@ export async function getAllTeamInfo() {
     return null;
   }
 }
+
+// GETS ALL TEAMS INFORMATION FROM fp_teams AND fp_members TABLES IN DATABASE. SEARCH QUERY INCLUDED
 
 export async function getAllTeamAndMembersInfo(searchTerm) {
   try {
@@ -64,6 +63,7 @@ function extractOwnerAndRepoFromUrl(url) {
 }
 
 // GETS SPECIFIC INFORMATION FROM BOTH fp_teams and fp_members TABLES AND JOINING THEM BY THEIR CORRESPONDING FOREIGN AND PRIMARY KEYS
+
 export async function getAllTeamRepos() {
   try {
     const result = await dataBase.query(
@@ -96,8 +96,6 @@ export async function getAllTeamRepos() {
         }
       });
 
-      // console.log(teamDataInfo);
-
       return teamDataInfo;
     }
   } catch (error) {
@@ -107,6 +105,7 @@ export async function getAllTeamRepos() {
 
 // USES THE INFORMATION OBTAINED FROM THE getAllTeamRepos FUNCTION TO CREATE AN ARRAY OF OBJECTS FOR EACH TEAM
 // THIS INCLUDES THE NUMBER OF PULL REQUESTS DONE BY EACH MEMBER OF THE TEAM BASED ON THEIR GITHUB USERNAME
+
 export async function getAllTeamMembersPRs() {
   try {
     const allTeamsRepos = await getAllTeamRepos();

--- a/server/repositories/teamsRepository.js
+++ b/server/repositories/teamsRepository.js
@@ -63,24 +63,37 @@ function extractOwnerAndRepoFromUrl(url) {
   return { owner, repo };
 }
 
+// GETS SPECIFIC INFORMATION FROM BOTH fp_teams and fp_members TABLES AND JOINING THEM BY THEIR CORRESPONDING FOREIGN AND PRIMARY KEYS
 export async function getAllTeamRepos() {
   try {
     const result = await dataBase.query(
-      "SELECT id, repo_link, team_name FROM fp_teams"
+      "SELECT fpt.id, fpt.repo_link, fpt.team_name, fpm.github_username FROM fp_teams fpt INNER JOIN fp_members fpm ON fpt.id = fpm.team_id"
     );
     if (result.rowCount === 0) {
       console.log("No teams available");
     } else {
-      const teamDataInfo = result.rows.map((eachTeamDataInfo) => {
+      const teamDataInfo = [];
+
+      result.rows.forEach((eachTeamDataInfo) => {
         const { owner, repo } = extractOwnerAndRepoFromUrl(
           eachTeamDataInfo.repo_link
         );
-        return {
-          id: eachTeamDataInfo.id,
-          teamName: eachTeamDataInfo.team_name,
-          owner: owner,
-          repo: repo,
-        };
+
+        const existingTeam = teamDataInfo.find(
+          (team) => team.id === eachTeamDataInfo.id
+        );
+
+        if (existingTeam) {
+          existingTeam.authors.push(eachTeamDataInfo.github_username);
+        } else {
+          teamDataInfo.push({
+            id: eachTeamDataInfo.id,
+            teamName: eachTeamDataInfo.team_name,
+            owner: owner,
+            repository: repo,
+            authors: [eachTeamDataInfo.github_username],
+          });
+        }
       });
 
       // console.log(teamDataInfo);
@@ -92,95 +105,39 @@ export async function getAllTeamRepos() {
   }
 }
 
+// USES THE INFORMATION OBTAINED FROM THE getAllTeamRepos FUNCTION TO CREATE AN ARRAY OF OBJECTS FOR EACH TEAM
+// THIS INCLUDES THE NUMBER OF PULL REQUESTS DONE BY EACH MEMBER OF THE TEAM BASED ON THEIR GITHUB USERNAME
 export async function getAllTeamMembersPRs() {
   try {
     const allTeamsRepos = await getAllTeamRepos();
-    // console.log(allTeamsRepos);
 
     const results = [];
 
     for (const repo of allTeamsRepos) {
-      // const ghURL = `https://api.github.com/search/issues?q=is:pr+repo:${repo.owner}/${repo.repo}/+author:${repo.author}`;
-
-      const apiURL = `https://api.github.com/repos/${repo.owner}/${repo.repo}/pulls?state=all`;
-
-      const response = await fetch(apiURL, {
-        headers: {
-          Authorization: `Bearer ${process.env.TOKEN}`,
-        },
-      });
-
-      const responseData = await response.json();
-
-      const newResponse = responseData.map((eachUser) => eachUser.user.login);
-
-      const pullRequestCount = responseData.length;
-
-      const prCount = async (users) => {
-        const count = {};
-
-        for (let eachName of users) {
-          count[eachName] = count[eachName] ? count[eachName] + 1 : 1;
-        }
-        // console.log(count);
-        return count;
-      };
-
-      const eachPRCount = await prCount(newResponse);
-
-      results.push({
+      const startingTeamInfo = {
         id: repo.id,
         teamName: repo.teamName,
         owner: repo.owner,
-        repo: repo.repo,
-        pullRequestCount: pullRequestCount,
-        users: eachPRCount,
-      });
-    }
-    console.log(results);
-    return results;
-  } catch (error) {
-    console.error("Error fetching pull requests:", error);
-    res.status(500).json({ error: "Internal server error" });
-  }
-}
+        repo: repo.repository,
+        pullRequestCount: 0,
+        users: {},
+      };
 
-export async function getTeamAndMemberInfo(teamID) {
-  try {
-    const getQuery = "SELECT id, repo_link, team_name FROM fp_teams";
-    const idQuery = "WHERE id = $1";
+      for (const author of repo.authors) {
+        const ghURL = `https://api.github.com/search/issues?q=is:pr+repo:${repo.owner}/${repo.repository}+author:${author}`;
 
-    const result = await dataBase.query(getQuery + " " + idQuery, [teamID]);
-    if (result.rowCount === 0) {
-      console.log("No teams available");
-    } else {
-      const teamDataInfo = result.rows.map((eachTeamDataInfo) => {
-        const { owner, repo } = extractOwnerAndRepoFromUrl(
-          eachTeamDataInfo.repo_link
-        );
-        return {
-          id: eachTeamDataInfo.id,
-          teamName: eachTeamDataInfo.team_name,
-          owner: owner,
-          repo: repo,
-        };
-      });
-
-      const resultInfo = [];
-
-      for (const repo of teamDataInfo) {
-        const apiUrl = `https://api.github.com/repos/${repo.owner}/${repo.repo}/pulls?state=all`;
-
-        const response = await fetch(apiUrl, {
+        const response = await fetch(ghURL, {
           headers: {
             Authorization: `Bearer ${process.env.TOKEN}`,
           },
         });
         const responseData = await response.json();
 
-        const newResponse = responseData.map((eachUser) => eachUser.user.login);
-        console.log(newResponse);
-        const pullRequestCount = responseData.length;
+        const newResponse = responseData.items.map(
+          (eachUser) => eachUser.user.login
+        );
+
+        const pullRequestCount = responseData.items.length;
 
         const prCount = async (users) => {
           const count = {};
@@ -188,23 +145,122 @@ export async function getTeamAndMemberInfo(teamID) {
           for (let eachName of users) {
             count[eachName] = count[eachName] ? count[eachName] + 1 : 1;
           }
-          // console.log(count);
           return count;
         };
 
         const eachPRCount = await prCount(newResponse);
 
-        resultInfo.push({
+        startingTeamInfo.pullRequestCount =
+          startingTeamInfo.pullRequestCount + pullRequestCount;
+
+        for (const user in eachPRCount) {
+          if (startingTeamInfo.users[user]) {
+            startingTeamInfo.users[user] += eachPRCount[user];
+          } else {
+            startingTeamInfo.users[user] = eachPRCount[user];
+          }
+        }
+      }
+
+      results.push(startingTeamInfo);
+    }
+
+    return results;
+  } catch (error) {
+    console.error("Error fetching pull requests:", error);
+    throw error;
+  }
+}
+
+// FINDS A SPECIFIC TEAM INFORMATION DEPENDING ON THE ID
+export async function getTeamAndMemberInfo(teamID) {
+  try {
+    const getQuery =
+      "SELECT fpt.id, fpt.repo_link, fpt.team_name, fpm.github_username FROM fp_teams fpt INNER JOIN fp_members fpm ON fpt.id = fpm.team_id";
+    const idQuery = "WHERE fpt.id = $1";
+
+    const result = await dataBase.query(getQuery + " " + idQuery, [teamID]);
+    if (result.rowCount === 0) {
+      console.log("No teams available");
+    } else {
+      const teamDataInfo = [];
+
+      result.rows.map((eachTeamDataInfo) => {
+        const { owner, repo } = extractOwnerAndRepoFromUrl(
+          eachTeamDataInfo.repo_link
+        );
+
+        const existingTeam = teamDataInfo.find(
+          (team) => team.id === eachTeamDataInfo.id
+        );
+
+        if (existingTeam) {
+          existingTeam.authors.push(eachTeamDataInfo.github_username);
+        } else {
+          teamDataInfo.push({
+            id: eachTeamDataInfo.id,
+            teamName: eachTeamDataInfo.team_name,
+            owner: owner,
+            repository: repo,
+            authors: [eachTeamDataInfo.github_username],
+          });
+        }
+      });
+
+      const resultInfo = [];
+
+      for (const repo of teamDataInfo) {
+        const startingTeamInfo = {
           id: repo.id,
           teamName: repo.teamName,
           owner: repo.owner,
-          repo: repo.repo,
-          pullRequestCount: pullRequestCount,
-          users: eachPRCount,
-        });
+          repo: repo.repository,
+          pullRequestCount: 0,
+          users: {},
+        };
+
+        for (const author of repo.authors) {
+          const ghURL = `https://api.github.com/search/issues?q=is:pr+repo:${repo.owner}/${repo.repository}+author:${author}`;
+
+          const response = await fetch(ghURL, {
+            headers: {
+              Authorization: `Bearer ${process.env.TOKEN}`,
+            },
+          });
+          const responseData = await response.json();
+
+          const newResponse = responseData.items.map(
+            (eachUser) => eachUser.user.login
+          );
+
+          const pullRequestCount = responseData.items.length;
+
+          const prCount = async (users) => {
+            const count = {};
+
+            for (let eachName of users) {
+              count[eachName] = count[eachName] ? count[eachName] + 1 : 1;
+            }
+            return count;
+          };
+
+          const eachPRCount = await prCount(newResponse);
+
+          startingTeamInfo.pullRequestCount =
+            startingTeamInfo.pullRequestCount + pullRequestCount;
+
+          for (const user in eachPRCount) {
+            if (startingTeamInfo.users[user]) {
+              startingTeamInfo.users[user] += eachPRCount[user];
+            } else {
+              startingTeamInfo.users[user] = eachPRCount[user];
+            }
+          }
+        }
+
+        resultInfo.push(startingTeamInfo);
       }
 
-      console.log(resultInfo);
       return resultInfo;
     }
   } catch (error) {


### PR DESCRIPTION
Changed the GitHub fetch url to include author. This fixes the bug we were encountering regarding team pr counts not being up to date. Now each teams PR count is up to date with GitHub.
Previous code only gave a limit of 30 pull request counts per repo.

The code reads from teamsRepository which handles requests to the database and combines it with requests to Github's Rest API. 
The resulting data is imported into teamsController which will include request parameters and sends a status code.
This is then imported into router which tells you what request the code is making and to what path.
Comments are present throughout the code to specify what code blocks do

example of resulting object in an array will be as shown (using the Hub Planner team as an example):  
{
        "id": 36,
        "teamName": "Hub Planner",
        "owner": "MariAzhdari",
        "repo": "finalProject-HubPlanner",
        "pullRequestCount": 65,
        "users": {
            "elahemortazavi": 26,
            "MariAzhdari": 19,
            "mickeyhaile2": 20
        }
    }